### PR TITLE
feat: intentionally break Dockerfile for testing GitHub Actions

### DIFF
--- a/2025cloud/python-app/Dockerfile
+++ b/2025cloud/python-app/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3.9-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Intentionally wrong file name to cause build failure
+COPY requirements.txt.wrong .
+RUN pip install --no-cache-dir -r requirements.txt.wrong
 
-COPY app.py .
+# Intentionally wrong file name to cause build failure
+COPY app.py.wrong .
 
-CMD ["python", "app.py"] 
+# Intentionally wrong command to cause runtime failure
+CMD ["python", "wrong_app.py"] 


### PR DESCRIPTION
   # Test GitHub Actions Failure Detection

   This PR intentionally breaks the Dockerfile to test GitHub Actions failure detection.

   ## Changes Made
   - Changed requirements.txt to requirements.txt.wrong
   - Changed app.py to app.py.wrong
   - Changed the CMD to run a non-existent file

   ## Expected Results
   GitHub Actions should fail during the build process due to missing files.